### PR TITLE
Fix error “unsupported operand type(s) for +: 'int' and 'dict'”

### DIFF
--- a/dss/applications/processor.py
+++ b/dss/applications/processor.py
@@ -5,16 +5,26 @@ def calculate_user_type_percentages(data: List[Dict]) -> Dict[str, float]:
     Tính tỷ lệ phần trăm từng loại khách hàng dựa trên tổng amount.
 
     Args:
-        data (List[Dict]): Danh sách dict với keys: 'user_type' (str), 'amount' (int)
+        data (List[Dict]): Danh sách dict với keys: 'user_type' (str), 'amount' (int/float)
 
     Returns:
         Dict[str, float]: {'New': x%, 'Returning': y%, ...}
     """
-    total = sum(entry["amount"] for entry in data)
-    if total == 0:
-        return {entry["user_type"]: 0.0 for entry in data}
+    user_type_totals: Dict[str, float] = {}
+
+    for entry in data:
+        user_type = entry.get("user_type")
+        amount = entry.get("amount")
+
+        if isinstance(user_type, str) and isinstance(amount, (int, float)):
+            user_type_totals[user_type] = user_type_totals.get(user_type, 0) + amount
+
+    total_amount = sum(user_type_totals.values())
+
+    if total_amount == 0:
+        return {k: 0.0 for k in user_type_totals}
 
     return {
-        entry["user_type"]: round(entry["amount"] / total * 100, 2)
-        for entry in data
+        user_type: round(amount / total_amount * 100, 2)
+        for user_type, amount in user_type_totals.items()
     }


### PR DESCRIPTION
Lọc ra những entry hợp lệ (có key "amount" và giá trị là int hoặc float).

Tránh tính nhiều lần cho cùng một loại user_type (nếu cần gộp).